### PR TITLE
feat: add optional file parameter on octopilot exec cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ It can update repositories based on specific branch instead of the HEAD one's if
 - The option `--repo "xxx/yyy(branch=xyz)"` will update the repo `xxx/yyy` based on the `xyz` branch if it exists
 - The option `--repo "xxx/yyy"` will update the repo xxx/yyy based on the `HEAD` branch as usual
 
+It can exec command and expand files on it, only if precised on the optionnal `file` parameter
+- The expanded file(s) will always be after the command arguments, at the end of the command line
+-  Example: If there a single file `test.yml` or the current directory
+    - The option `--update 'exec(cmd=ls,file=test.y*ml,args=-lrt,stdout=ls-result.stdout)'`
+        - will exec the command `ls -lrt /path/to/current_dir/test.yml`
+        - will write the output of the command on `/path/to/current_dir/ls-result.stdout`
+
 It is somewhat based on [updatebot](https://github.com/jenkins-x/updatebot), but written in [Go](https://golang.org/), and with more features:
 - supports running multiple "updaters" in the same execution - for example create a PR with both a sops change and a regex change
 - run any tool to update a repo


### PR DESCRIPTION
From source https://golang.org/pkg/os/exec/ : 

`Unlike the "system" library call from C and other languages, the os/exec package intentionally does not invoke the system shell and does not expand any glob patterns or handle other expansions, pipelines, or redirections typically done by shells.`

This commit aims at providing the possibility to expand files on the case we execute a command with octopilot.
This is done through an optional `file` parameter on the octopilot update exec