### PR TITLE
chore: upgrade tools - go, goreleaser, golangci-lint

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -15,11 +15,11 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2.1.3
         with:
-          go-version: '1.15'
+          go-version: '1.16'
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2.6.1
         with:
-          version: v0.143.0
+          version: v0.171.0
           args: release --snapshot --skip-publish --rm-dist
 
   unit-tests:
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2.1.3
         with:
-          go-version: '1.15'
+          go-version: '1.16'
       - name: Run Unit Tests
         run: go test -v ./...
 
@@ -42,4 +42,4 @@ jobs:
       - name: Run linters
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.37
+          version: v1.41.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2.1.3
         with:
-          go-version: '1.15'
+          go-version: '1.16'
 
       - name: Login to GitHub Packages Docker Registry
         uses: docker/login-action@v1
@@ -30,7 +30,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2.6.1
         with:
-          version: v0.143.0
+          version: v0.171.0
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,7 +1,7 @@
 # Dockerfile used by GoReleaser
 # Requires the binary to be pre-built
 
-FROM alpine:3.12
+FROM alpine:3.14
 
 RUN apk add --no-cache ca-certificates
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dailymotion-oss/octopilot
 
-go 1.15
+go 1.16
 
 require (
 	github.com/Azure/go-autorest/autorest v0.9.7 // indirect


### PR DESCRIPTION
upgrade:
- go to 1.16
- goreleaser to 0.171.0
- golangci-lint to 1.41.1
- alpine base image to 3.14