### PR TITLE
chore: fix github actions unit tests workflow

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -2,7 +2,11 @@
 
 name: unit-tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   unit-tests:


### PR DESCRIPTION
ensure we don't run the unit tests twice for PRs (push & pr events)