### PR TITLE
feat: add a flag to exit with error code when an update fails

### DIFF
--- a/docs/current-version/content/use-cases/detecting-errors-in-scripts.md
+++ b/docs/current-version/content/use-cases/detecting-errors-in-scripts.md
@@ -1,0 +1,7 @@
+---
+title: "Detecting errors in scripts"
+anchor: "detecting-errors-in-scripts"
+weight: 50
+---
+
+By default Octopilot does not exit with error even when updates fail. Add the `--fail-on-error` flag so that Octopilot exits with error when updates fail.


### PR DESCRIPTION
Add the `--fail-on-error` flag so that Octopilot exits with errors when the update fails.

My use case is to easily detect in automation when an updated errored. At the moment, the only way I've found is to parse the output for errors, which is not very reliable :slightly_smiling_face: 