### PR TITLE
fix: allow using octopilot on repositories with .(dot) inside them

### DIFF
--- a/repository/repository.go
+++ b/repository/repository.go
@@ -20,7 +20,7 @@ var (
 	repoRegexp = regexp.MustCompile(`^(?P<type>[A-Za-z0-9_\-/]+)(?:\((?P<params>.+)\))?$`)
 
 	// owner/name(params)
-	repoWithNameRegexp = regexp.MustCompile(`^(?P<owner>[A-Za-z0-9_\-]+)/(?P<name>[A-Za-z0-9_\-]+)(?:\((?P<params>.+)\))?$`)
+	repoWithNameRegexp = regexp.MustCompile(`^(?P<owner>[A-Za-z0-9_\-]+)/(?P<name>[A-Za-z0-9._\-]+)(?:\((?P<params>.+)\))?$`)
 )
 
 // Repository is a representation of a GitHub repository.


### PR DESCRIPTION
Hello, 

I am using repositories with `.` inside them Example: `github/github.infra`. 
Currently octopilot can not be used inside such repositories. Regexp will not allow it.
This PR will fix this