### PR TITLE
feat: add flag to support Enterprise GitHub 

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -10,7 +10,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Setup Go
+        uses: actions/setup-go@v3.5.0
+        with:
+          go-version-file: 'go.mod'
+
       - name: Run linters
         uses: golangci/golangci-lint-action@v3.4.0
         with:
-          version: v1.47.2
+          version: v1.51.2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,21 +18,20 @@ linters:
     - thelper
     - unconvert
     - unparam
-    - wastedassign
     - whitespace
 
 linters-settings:
   gosimple:
-    go: "1.18"
+    go: "1.19"
     checks: ["all"]
   staticcheck:
-    go: "1.18"
+    go: "1.19"
     checks: ["all"]
   stylecheck:
-    go: "1.18"
+    go: "1.19"
     checks: ["all"]
   unused:
-    go: "1.18"
+    go: "1.19"
   errorlint:
     errorf: true
     asserts: true

--- a/docs/current-version/content/github/_index.md
+++ b/docs/current-version/content/github/_index.md
@@ -34,3 +34,18 @@ First, you'll need to set the `--github-auth-token` flag value to `app`, and the
 See GitHub's documentation for more details on:
 - [Creating a GitHub App](https://docs.github.com/en/developers/apps/building-github-apps/creating-a-github-app)
 - [Authenticating with GitHub Apps](https://docs.github.com/en/developers/apps/building-github-apps/authenticating-with-github-apps)
+
+## Using octopilot with Enterprise GitHub
+
+By default, octopilot will operate on repositories hosted on https://github.com. Octopilot can work on repositories hosted on an Enterprise Github servers by adding the `--github-url` flag.
+This flag must be set to the URL of the Enterprise GitHub server (the URL used to browse to the GitHub server main page). Authentication is usually required using any of the authentication method described above.
+
+Example of use:
+
+```bash
+
+$ octopilot \
+    --github-url https://mygitserver.acme.com \
+    --repo "${ORG_NAME}/test-repo" \
+    ...
+```

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dailymotion-oss/octopilot
 
-go 1.18
+go 1.19
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.3

--- a/internal/git/config_test.go
+++ b/internal/git/config_test.go
@@ -14,7 +14,7 @@ import (
 func TestFindGitDirectory(t *testing.T) {
 	baseDir, err := os.Getwd()
 	require.NoError(t, err, "failed to get the current working directory")
-	defer os.Chdir(baseDir) // nolint: errcheck // don't care in the tests...
+	defer os.Chdir(baseDir) //nolint: errcheck // don't care in the tests...
 
 	// copy the "git" dir to ".git", because otherwise it's a pain to commit a .git dir ;-)
 	err = copy.Copy(
@@ -61,7 +61,7 @@ func TestFindGitDirectory(t *testing.T) {
 func TestCurrentRepositoryURL(t *testing.T) {
 	baseDir, err := os.Getwd()
 	require.NoError(t, err, "failed to get the current working directory")
-	defer os.Chdir(baseDir) // nolint: errcheck // don't care in the tests...
+	defer os.Chdir(baseDir) //nolint: errcheck // don't care in the tests...
 
 	gitDir := filepath.Join(baseDir, "testdata", "dir-with-git-config")
 	err = os.Chdir(gitDir)

--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -49,6 +48,7 @@ func init() {
 	pflag.Int64Var(&options.GitHub.InstallationID, "github-installation-id", int64(getenvInt("GITHUB_INSTALLATION_ID")), "For the `app` GitHub auth method, contains the GitHubApp Installation ID. Default to the GITHUB_INSTALLATION_ID env var.")
 	pflag.StringVar(&options.GitHub.PrivateKey, "github-privatekey", os.Getenv("GITHUB_PRIVATEKEY"), "For the `app` GitHub auth method, contains the GitHubApp Private key file in PEM format. Default to the GITHUB_PRIVATEKEY env var.")
 	pflag.StringVar(&options.GitHub.PrivateKeyPath, "github-privatekey-path", os.Getenv("GITHUB_PRIVATEKEY_PATH"), "For the `app` GitHub auth method, contains the GitHubApp Private key file path `/some/key.pem` (used if the github-privatekey is empty). Default to the GITHUB_PRIVATEKEY_PATH env var.")
+	pflag.StringVar(&options.GitHub.URL, "github-url", repository.PublicGithubURL, `GitHub server URL`)
 
 	// pull-request flags
 	pflag.StringVar(&options.GitHub.PullRequest.Title, "pr-title", "", "The title of the Pull Request to create. Default to the commit title.")
@@ -211,7 +211,7 @@ func printHelpOrVersion() {
 }
 
 func temporaryDirectory() string {
-	dir, err := ioutil.TempDir("", "octopilot")
+	dir, err := os.MkdirTemp("", "octopilot")
 	if err != nil {
 		dir = filepath.Join(os.TempDir(), "octopilot")
 	}

--- a/repository/git_test.go
+++ b/repository/git_test.go
@@ -2,7 +2,7 @@ package repository
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -37,7 +37,7 @@ func TestSwitchBranch(t *testing.T) {
 				require.NoError(t, err)
 				f, err := workTree.Filesystem.Open("master-branch.txt")
 				require.NoError(t, err)
-				data, err := ioutil.ReadAll(f)
+				data, err := io.ReadAll(f)
 				require.NoError(t, err)
 				assert.Equal(t, "this is a file from the master branch\n", string(data))
 			},
@@ -58,7 +58,7 @@ func TestSwitchBranch(t *testing.T) {
 				require.NoError(t, err)
 				f, err := workTree.Filesystem.Open("update-branch.txt")
 				require.NoError(t, err)
-				data, err := ioutil.ReadAll(f)
+				data, err := io.ReadAll(f)
 				require.NoError(t, err)
 				assert.Equal(t, "this is a file from the update branch\n", string(data))
 			},

--- a/repository/options.go
+++ b/repository/options.go
@@ -14,6 +14,8 @@ const (
 	ReplaceUpdateOperation = "replace"
 	PrependUpdateOperation = "prepend"
 	AppendUpdateOperation  = "append"
+
+	PublicGithubURL = "https://github.com"
 )
 
 // UpdateOptions is the options entrypoint for a git repo update
@@ -42,6 +44,7 @@ type GitOptions struct {
 
 // GitHubOptions holds all the options required to perform github operations: auth, PRs, ...
 type GitHubOptions struct {
+	URL            string
 	AuthMethod     string
 	Token          string
 	AppID          int64
@@ -49,6 +52,10 @@ type GitHubOptions struct {
 	PrivateKey     string
 	PrivateKeyPath string
 	PullRequest    PullRequestOptions
+}
+
+func (o *GitHubOptions) isEnterprise() bool {
+	return o.URL != PublicGithubURL
 }
 
 // PullRequestOptions holds all the options required to perform github PR operations: title/body, merge, ...

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -210,3 +210,8 @@ func (r Repository) adjustOptionsFromParams(options *UpdateOptions) {
 func (r Repository) FullName() string {
 	return fmt.Sprintf("%s/%s", r.Owner, r.Name)
 }
+
+// FullName returns the repository full name with the git extension
+func (r Repository) GitFullName() string {
+	return fmt.Sprintf("%s/%s.git", r.Owner, r.Name)
+}

--- a/repository/template.go
+++ b/repository/template.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -54,7 +54,7 @@ func tplReadFileFunc(repoPath string) func(string) string {
 		if !filepath.IsAbs(path) {
 			path = filepath.Join(repoPath, path)
 		}
-		content, err := ioutil.ReadFile(path)
+		content, err := os.ReadFile(path)
 		if err != nil {
 			panic(fmt.Sprintf("failed to readFile %s: %v", path, err))
 		}

--- a/update/exec/exec.go
+++ b/update/exec/exec.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -121,7 +120,7 @@ func (u *ExecUpdater) writeCmdOutputToFile(output bytes.Buffer, repoPath, filePa
 		return fmt.Errorf("failed to create directory %s: %w", filepath.Dir(filePath), err)
 	}
 
-	err = ioutil.WriteFile(filePath, output.Bytes(), 0644)
+	err = os.WriteFile(filePath, output.Bytes(), 0644)
 	if err != nil {
 		return fmt.Errorf("failed to write output of cmd '%s' to %s: %w", u.Command, filePath, err)
 	}

--- a/update/exec/exec_test.go
+++ b/update/exec/exec_test.go
@@ -3,7 +3,6 @@ package exec
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -148,7 +147,7 @@ func TestUpdate(t *testing.T) {
 			},
 			expected: true,
 			extraCheck: func() bool {
-				actualFileContent, _ := ioutil.ReadFile(filepath.Join("testdata", "file-to-print.stdout"))
+				actualFileContent, _ := os.ReadFile(filepath.Join("testdata", "file-to-print.stdout"))
 				return bytes.Equal(actualFileContent, []byte("some content"))
 			},
 		},
@@ -165,7 +164,7 @@ func TestUpdate(t *testing.T) {
 			},
 			expected: true,
 			extraCheck: func() bool {
-				actualFileContent, _ := ioutil.ReadFile(filepath.Join("testdata", "ls-result.stdout"))
+				actualFileContent, _ := os.ReadFile(filepath.Join("testdata", "ls-result.stdout"))
 				return bytes.Equal(actualFileContent, []byte("sh-c-file-to-list.txt\n"))
 			},
 		},
@@ -179,7 +178,7 @@ func TestUpdate(t *testing.T) {
 				for filename, content := range test.files {
 					err := os.MkdirAll(filepath.Dir(filepath.Join("testdata", filename)), 0755)
 					require.NoErrorf(t, err, "can't create testdata directories for %s", filename)
-					err = ioutil.WriteFile(filepath.Join("testdata", filename), []byte(content), 0644)
+					err = os.WriteFile(filepath.Join("testdata", filename), []byte(content), 0644)
 					require.NoErrorf(t, err, "can't write testdata file %s", filename)
 				}
 			}

--- a/update/helm/helm.go
+++ b/update/helm/helm.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -75,7 +74,7 @@ func (u *HelmUpdater) Update(ctx context.Context, repoPath string) (bool, error)
 }
 
 func (u *HelmUpdater) updateChartDependenciesFile(filePath string, version string) (bool, error) {
-	data, err := ioutil.ReadFile(filePath)
+	data, err := os.ReadFile(filePath)
 	if err != nil {
 		return false, fmt.Errorf("failed to read file %s: %w", filePath, err)
 	}

--- a/update/helm/helm_test.go
+++ b/update/helm/helm_test.go
@@ -2,7 +2,6 @@ package helm
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -216,7 +215,7 @@ dependencies:
 				for filename, content := range test.files {
 					err := os.MkdirAll(filepath.Dir(filepath.Join("testdata", filename)), 0755)
 					require.NoErrorf(t, err, "can't create testdata directories for %s", filename)
-					err = ioutil.WriteFile(filepath.Join("testdata", filename), []byte(content), 0644)
+					err = os.WriteFile(filepath.Join("testdata", filename), []byte(content), 0644)
 					require.NoErrorf(t, err, "can't write testdata file %s", filename)
 				}
 			}
@@ -230,7 +229,7 @@ dependencies:
 				assert.Equal(t, test.expected, actual)
 				for expectedFilePath, expectedFileContent := range test.expectedFiles {
 					actualFilePath := filepath.Join("testdata", expectedFilePath)
-					actualFileContent, err := ioutil.ReadFile(actualFilePath)
+					actualFileContent, err := os.ReadFile(actualFilePath)
 					require.NoErrorf(t, err, "can't read actual testdata file %s", actualFilePath)
 					assert.Equalf(t, expectedFileContent, string(actualFileContent), "testdata file %s doesn't match", actualFilePath)
 				}

--- a/update/regex/regex.go
+++ b/update/regex/regex.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -74,7 +73,7 @@ func (u RegexUpdater) Update(ctx context.Context, repoPath string) (bool, error)
 			return false, fmt.Errorf("failed to access file %s: %w", relFilePath, err)
 		}
 
-		content, err := ioutil.ReadFile(filePath)
+		content, err := os.ReadFile(filePath)
 		if err != nil {
 			return false, fmt.Errorf("failed to read file %s: %w", relFilePath, err)
 		}
@@ -105,7 +104,7 @@ func (u RegexUpdater) Update(ctx context.Context, repoPath string) (bool, error)
 			return false, fmt.Errorf("failed to copy existing content to the buffer: %w", err)
 		}
 
-		if err = ioutil.WriteFile(filePath, updatedContent.Bytes(), fileInfo.Mode()); err != nil {
+		if err = os.WriteFile(filePath, updatedContent.Bytes(), fileInfo.Mode()); err != nil {
 			return false, fmt.Errorf("failed to write updated content to file %s: %w", relFilePath, err)
 		}
 

--- a/update/regex/regex_test.go
+++ b/update/regex/regex_test.go
@@ -2,7 +2,6 @@ package regex
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -294,7 +293,7 @@ releases:
 				for filename, content := range test.files {
 					err := os.MkdirAll(filepath.Dir(filepath.Join("testdata", filename)), 0755)
 					require.NoErrorf(t, err, "can't create testdata directories for %s", filename)
-					err = ioutil.WriteFile(filepath.Join("testdata", filename), []byte(content), 0644)
+					err = os.WriteFile(filepath.Join("testdata", filename), []byte(content), 0644)
 					require.NoErrorf(t, err, "can't write testdata file %s", filename)
 				}
 			}
@@ -311,7 +310,7 @@ releases:
 				for _, actualFilePath := range actualFilePaths {
 					actualRelFilePath, err := filepath.Rel("testdata", actualFilePath)
 					require.NoErrorf(t, err, "can't get relative path for actual testdata file %s", actualFilePath)
-					actualFileContent, err := ioutil.ReadFile(actualFilePath)
+					actualFileContent, err := os.ReadFile(actualFilePath)
 					require.NoErrorf(t, err, "can't read actual testdata file %s", actualFilePath)
 					expectedFileContent := test.expectedFiles[actualRelFilePath]
 					assert.Equalf(t, expectedFileContent, string(actualFileContent), "testdata file %s doesn't match", actualFilePath)

--- a/update/sops/sops.go
+++ b/update/sops/sops.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -144,7 +143,7 @@ func (u SopsUpdater) Update(ctx context.Context, repoPath string) (bool, error) 
 			return false, fmt.Errorf("failed to generate re-encrypted file %s: %w", filePath, err)
 		}
 
-		err = ioutil.WriteFile(filePath, encryptedFile, fileInfo.Mode())
+		err = os.WriteFile(filePath, encryptedFile, fileInfo.Mode())
 		if err != nil {
 			return false, fmt.Errorf("failed to write re-encrypted data to file %s: %w", filePath, err)
 		}

--- a/update/sops/sops_test.go
+++ b/update/sops/sops_test.go
@@ -2,7 +2,6 @@ package sops
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -234,7 +233,7 @@ newtoken: new-token-value
 					require.NoErrorf(t, err, "failed to encrypt file %s", filename)
 					encryptedData, err := store.EmitEncryptedFile(tree)
 					require.NoErrorf(t, err, "failed to generate encrypted file %s", filename)
-					err = ioutil.WriteFile(filepath.Join("testdata", filename), encryptedData, 0644)
+					err = os.WriteFile(filepath.Join("testdata", filename), encryptedData, 0644)
 					require.NoErrorf(t, err, "failed to write encrypted data to file %s", filename)
 				}
 			}
@@ -247,7 +246,7 @@ newtoken: new-token-value
 				require.NoError(t, err)
 				assert.Equal(t, test.expected, actual)
 
-				actualEncryptedData, err := ioutil.ReadFile(filepath.Join("testdata", test.updater.FilePath))
+				actualEncryptedData, err := os.ReadFile(filepath.Join("testdata", test.updater.FilePath))
 				require.NoError(t, err, "can't read actual encrypted file")
 				actualCleartextData, err := decrypt.DataWithFormat(actualEncryptedData, formats.FormatForPath(test.updater.FilePath))
 				require.NoError(t, err, "can't decrypt actual encrypted content")

--- a/update/value/file.go
+++ b/update/value/file.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 )
 
@@ -30,7 +30,7 @@ func (v FileValuer) Value(_ context.Context, repoPath string) (string, error) {
 	if !filepath.IsAbs(filePath) {
 		filePath = filepath.Join(repoPath, v.Path)
 	}
-	content, err := ioutil.ReadFile(filePath)
+	content, err := os.ReadFile(filePath)
 	if err != nil {
 		return "", fmt.Errorf("failed to read file %s: %w", v.Path, err)
 	}

--- a/update/yaml/yaml.go
+++ b/update/yaml/yaml.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -102,7 +101,7 @@ func (u *YamlUpdater) Update(ctx context.Context, repoPath string) (bool, error)
 			return false, fmt.Errorf("failed to access file %s: %w", relFilePath, err)
 		}
 
-		fileData, err := ioutil.ReadFile(filePath)
+		fileData, err := os.ReadFile(filePath)
 		if err != nil {
 			return false, fmt.Errorf("failed to read file %s: %w", relFilePath, err)
 		}
@@ -127,7 +126,7 @@ func (u *YamlUpdater) Update(ctx context.Context, repoPath string) (bool, error)
 			continue
 		}
 
-		err = ioutil.WriteFile(filePath, buffer.Bytes(), fileInfo.Mode())
+		err = os.WriteFile(filePath, buffer.Bytes(), fileInfo.Mode())
 		if err != nil {
 			return false, fmt.Errorf("failed to write file %s: %w", filePath, err)
 		}

--- a/update/yaml/yaml_test.go
+++ b/update/yaml/yaml_test.go
@@ -2,7 +2,6 @@ package yaml
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -351,7 +350,7 @@ key: value
 				for filename, content := range test.files {
 					err := os.MkdirAll(filepath.Dir(filepath.Join("testdata", filename)), 0755)
 					require.NoErrorf(t, err, "can't create testdata directories for %s", filename)
-					err = ioutil.WriteFile(filepath.Join("testdata", filename), []byte(content), 0644)
+					err = os.WriteFile(filepath.Join("testdata", filename), []byte(content), 0644)
 					require.NoErrorf(t, err, "can't write testdata file %s", filename)
 				}
 			}
@@ -368,7 +367,7 @@ key: value
 				for _, actualFilePath := range actualFilePaths {
 					actualRelFilePath, err := filepath.Rel("testdata", actualFilePath)
 					require.NoErrorf(t, err, "can't get relative path for actual testdata file %s", actualFilePath)
-					actualFileContent, err := ioutil.ReadFile(actualFilePath)
+					actualFileContent, err := os.ReadFile(actualFilePath)
 					require.NoErrorf(t, err, "can't read actual testdata file %s", actualFilePath)
 					expectedFileContent := test.expectedFiles[actualRelFilePath]
 					assert.Equalf(t, expectedFileContent, string(actualFileContent), "testdata file %s doesn't match", actualFilePath)

--- a/update/yq/yq.go
+++ b/update/yq/yq.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -135,7 +134,7 @@ func (u *YQUpdater) Update(_ context.Context, repoPath string) (bool, error) {
 			return false, fmt.Errorf("failed to access file %s: %w", relFilePath, err)
 		}
 
-		fileData, err := ioutil.ReadFile(filePath)
+		fileData, err := os.ReadFile(filePath)
 		if err != nil {
 			return false, fmt.Errorf("failed to read file %s: %w", relFilePath, err)
 		}
@@ -164,7 +163,7 @@ func (u *YQUpdater) Update(_ context.Context, repoPath string) (bool, error) {
 			_, err = buffer.WriteTo(output)
 		} else {
 			// we need to write in-place in the same (source) file
-			err = ioutil.WriteFile(filePath, buffer.Bytes(), fileInfo.Mode())
+			err = os.WriteFile(filePath, buffer.Bytes(), fileInfo.Mode())
 		}
 		if err != nil {
 			return false, fmt.Errorf("failed to write yq result to the output: %w", err)

--- a/update/yq/yq_test.go
+++ b/update/yq/yq_test.go
@@ -2,7 +2,6 @@ package yq
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -409,7 +408,7 @@ key: value
 				for filename, content := range test.files {
 					err := os.MkdirAll(filepath.Dir(filepath.Join("testdata", filename)), 0755)
 					require.NoErrorf(t, err, "can't create testdata directories for %s", filename)
-					err = ioutil.WriteFile(filepath.Join("testdata", filename), []byte(content), 0644)
+					err = os.WriteFile(filepath.Join("testdata", filename), []byte(content), 0644)
 					require.NoErrorf(t, err, "can't write testdata file %s", filename)
 				}
 			}
@@ -430,7 +429,7 @@ key: value
 				for _, actualFilePath := range actualFilePaths {
 					actualRelFilePath, err := filepath.Rel("testdata", actualFilePath)
 					require.NoErrorf(t, err, "can't get relative path for actual testdata file %s", actualFilePath)
-					actualFileContent, err := ioutil.ReadFile(actualFilePath)
+					actualFileContent, err := os.ReadFile(actualFilePath)
 					require.NoErrorf(t, err, "can't read actual testdata file %s", actualFilePath)
 					expectedFileContent := test.expectedFiles[actualRelFilePath]
 					assert.Equalf(t, expectedFileContent, string(actualFileContent), "testdata file %s doesn't match", actualFilePath)


### PR DESCRIPTION
The --github-url flag can be used to operate on repositories hosted on an Enterprise Github server.
See the doc update for more information.
---
Tested on my work GitHub Enterprise Server 3.5.7 and working fine.
