### PR TITLE
chore: add daily-devops & daily-devexp in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,4 @@
 # https://help.github.com/en/articles/about-code-owners
 * @vbehar
+* @dailymotion-oss/daily-devops
+* @dailymotion-oss/daily-devexp


### PR DESCRIPTION
Description:

This PR adds daily-devops & daily-devexp teams in the CODEOWNERS file