### PR TITLE
feat: add flag --output-results

### DIFF
--- a/repository/repository.go
+++ b/repository/repository.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/dailymotion-oss/octopilot/internal/parameters"
 	"github.com/dailymotion-oss/octopilot/update"
+	"github.com/google/go-github/v36/github"
 	"github.com/rs/xid"
 	"github.com/sirupsen/logrus"
 )
@@ -102,7 +103,7 @@ func discoverRepositoriesFrom(ctx context.Context, params map[string]string, git
 
 // Update is the entrypoint to update a repository with a set of updaters.
 // It returns a boolean indicating whether the repository was updated or not.
-func (r Repository) Update(ctx context.Context, updaters []update.Updater, options UpdateOptions) (bool, error) {
+func (r Repository) Update(ctx context.Context, updaters []update.Updater, options UpdateOptions) (bool, *github.PullRequest, error) {
 	r.adjustOptionsFromParams(&options)
 
 	repoPath := filepath.Join(options.Git.CloneDir, r.Owner, r.Name)
@@ -157,31 +158,31 @@ func (r Repository) Update(ctx context.Context, updaters []update.Updater, optio
 
 	repoUpdated, pr, err := strategy.Run(ctx)
 	if err != nil {
-		return false, fmt.Errorf("%w", err)
+		return false, pr, fmt.Errorf("%w", err)
 	}
 	if !repoUpdated {
-		return false, nil
+		return false, pr, nil
 	}
 
 	if !options.GitHub.PullRequest.Merge.Enabled {
 		logrus.WithFields(logrus.Fields{
 			"repository": r.FullName(),
 		}).Debug("Pull Request merging is disabled")
-		return true, nil
+		return true, pr, nil
 	}
 	if pr == nil {
 		logrus.WithFields(logrus.Fields{
 			"repository": r.FullName(),
 		}).Warning("No Pull Request was created - can't merge it!")
-		return true, nil
+		return true, pr, nil
 	}
 
 	err = r.mergePullRequest(ctx, options.GitHub, pr)
 	if err != nil {
-		return true, fmt.Errorf("failed to merge Pull Request %s: %w", pr.GetHTMLURL(), err)
+		return true, pr, fmt.Errorf("failed to merge Pull Request %s: %w", pr.GetHTMLURL(), err)
 	}
 
-	return true, nil
+	return true, pr, nil
 }
 
 func (r Repository) runUpdaters(ctx context.Context, updaters []update.Updater, repoPath string) (bool, error) {

--- a/repository/result.go
+++ b/repository/result.go
@@ -1,0 +1,18 @@
+package repository
+
+type ResultFile struct {
+	Repos []RepoUpdateResult `json:"repos"`
+}
+
+type RepoUpdateResult struct {
+	Owner       string             `json:"owner"`
+	Repo        string             `json:"repo"`
+	Error       *string            `json:"error"`
+	PullRequest *PullRequestResult `json:"pr"`
+}
+
+type PullRequestResult struct {
+	Number int    `json:"number"`
+	NodeID string `json:"nodeId"`
+	URL    string `json:"url"`
+}


### PR DESCRIPTION
This will write the execution results in a JSON format to the specified file. Other tools/scripts may find this useful to provide additional automation.

The schema looks something like:

```json
{
  "repos": [
    {
      "owner": string,
      "repo": string,
      "error": null (if there were no errors) or string,
      "pr": null (if no pull-request was created) or {
        "number": int,
        "nodeId": string,
        "url": string,
      }
    }
    ...
  ]
}
```

#295