### PR TITLE
feat: improve the display of repositories pr url at the end

### DIFF
--- a/repository/result.go
+++ b/repository/result.go
@@ -9,6 +9,7 @@ type RepoUpdateResult struct {
 	Repo        string             `json:"repo"`
 	Error       *string            `json:"error"`
 	PullRequest *PullRequestResult `json:"pr"`
+	IsUpdated   bool
 }
 
 type PullRequestResult struct {

--- a/repository/strategy_append.go
+++ b/repository/strategy_append.go
@@ -44,36 +44,36 @@ func (s *AppendStrategy) Run(ctx context.Context) (bool, *github.PullRequest, er
 		})
 	}
 	if err != nil {
-		return false, nil, fmt.Errorf("failed to switch to branch %s: %w", branchName, err)
+		return false, existingPR, fmt.Errorf("failed to switch to branch %s: %w", branchName, err)
 	}
 
 	repoUpdated, err := s.Repository.runUpdaters(ctx, s.Updaters, s.RepoPath)
 	if err != nil {
-		return false, nil, fmt.Errorf("failed to update repository %s: %w", s.Repository.FullName(), err)
+		return false, existingPR, fmt.Errorf("failed to update repository %s: %w", s.Repository.FullName(), err)
 	}
 	if !repoUpdated {
-		return false, nil, nil
+		return false, existingPR, nil
 	}
 
 	if err = s.Options.Git.setDefaultValues(s.Updaters, templateExecutorFor(s.Options, s.Repository, s.RepoPath)); err != nil {
-		return false, nil, fmt.Errorf("failed to set default git values: %w", err)
+		return false, existingPR, fmt.Errorf("failed to set default git values: %w", err)
 	}
 	if err = s.Options.GitHub.setDefaultValues(s.Options.Git, templateExecutorFor(s.Options, s.Repository, s.RepoPath)); err != nil {
-		return false, nil, fmt.Errorf("failed to set default github values: %w", err)
+		return false, existingPR, fmt.Errorf("failed to set default github values: %w", err)
 	}
 	s.Options.GitHub.setDefaultUpdateOperation(IgnoreUpdateOperation)
 
 	changesCommitted, err := commitChanges(ctx, gitRepo, s.Options)
 	if err != nil {
-		return false, nil, fmt.Errorf("failed to commit changes to git repository %s: %w", s.Repository.FullName(), err)
+		return false, existingPR, fmt.Errorf("failed to commit changes to git repository %s: %w", s.Repository.FullName(), err)
 	}
 	if !changesCommitted {
 		logrus.WithField("repository", s.Repository.FullName()).Debug("No changes recorded, nothing to push")
-		return false, nil, nil
+		return false, existingPR, nil
 	}
 	if s.Options.DryRun {
 		logrus.WithField("repository", s.Repository.FullName()).Warning("Running in dry-run mode, not pushing changes")
-		return false, nil, nil
+		return false, existingPR, nil
 	}
 
 	err = pushChanges(ctx, gitRepo, pushOptions{
@@ -81,7 +81,7 @@ func (s *AppendStrategy) Run(ctx context.Context) (bool, *github.PullRequest, er
 		BranchName: branchName,
 	})
 	if err != nil {
-		return false, nil, fmt.Errorf("failed to push changes to git repository %s: %w", s.Repository.FullName(), err)
+		return false, existingPR, fmt.Errorf("failed to push changes to git repository %s: %w", s.Repository.FullName(), err)
 	}
 
 	var pr *github.PullRequest
@@ -91,7 +91,7 @@ func (s *AppendStrategy) Run(ctx context.Context) (bool, *github.PullRequest, er
 		pr, err = s.Repository.createPullRequest(ctx, s.Options.GitHub, branchName)
 	}
 	if err != nil {
-		return false, nil, fmt.Errorf("failed to create or update Pull Request: %w", err)
+		return false, existingPR, fmt.Errorf("failed to create or update Pull Request: %w", err)
 	}
 
 	return true, pr, nil

--- a/repository/strategy_reset.go
+++ b/repository/strategy_reset.go
@@ -42,36 +42,36 @@ func (s *ResetStrategy) Run(ctx context.Context) (bool, *github.PullRequest, err
 		CreateBranch: true,
 	})
 	if err != nil {
-		return false, nil, fmt.Errorf("failed to switch to branch %s: %w", branchName, err)
+		return false, existingPR, fmt.Errorf("failed to switch to branch %s: %w", branchName, err)
 	}
 
 	repoUpdated, err := s.Repository.runUpdaters(ctx, s.Updaters, s.RepoPath)
 	if err != nil {
-		return false, nil, fmt.Errorf("failed to update repository %s: %w", s.Repository.FullName(), err)
+		return false, existingPR, fmt.Errorf("failed to update repository %s: %w", s.Repository.FullName(), err)
 	}
 	if !repoUpdated {
-		return false, nil, nil
+		return false, existingPR, nil
 	}
 
 	if err = s.Options.Git.setDefaultValues(s.Updaters, templateExecutorFor(s.Options, s.Repository, s.RepoPath)); err != nil {
-		return false, nil, fmt.Errorf("failed to set default git values: %w", err)
+		return false, existingPR, fmt.Errorf("failed to set default git values: %w", err)
 	}
 	if err = s.Options.GitHub.setDefaultValues(s.Options.Git, templateExecutorFor(s.Options, s.Repository, s.RepoPath)); err != nil {
-		return false, nil, fmt.Errorf("failed to set default github values: %w", err)
+		return false, existingPR, fmt.Errorf("failed to set default github values: %w", err)
 	}
 	s.Options.GitHub.setDefaultUpdateOperation(ReplaceUpdateOperation)
 
 	changesCommitted, err := commitChanges(ctx, gitRepo, s.Options)
 	if err != nil {
-		return false, nil, fmt.Errorf("failed to commit changes to git repository %s: %w", s.Repository.FullName(), err)
+		return false, existingPR, fmt.Errorf("failed to commit changes to git repository %s: %w", s.Repository.FullName(), err)
 	}
 	if !changesCommitted {
 		logrus.WithField("repository", s.Repository.FullName()).Debug("No changes recorded, nothing to push")
-		return false, nil, nil
+		return false, existingPR, nil
 	}
 	if s.Options.DryRun {
 		logrus.WithField("repository", s.Repository.FullName()).Warning("Running in dry-run mode, not pushing changes")
-		return false, nil, nil
+		return false, existingPR, nil
 	}
 
 	err = pushChanges(ctx, gitRepo, pushOptions{
@@ -80,7 +80,7 @@ func (s *ResetStrategy) Run(ctx context.Context) (bool, *github.PullRequest, err
 		ForcePush:  true,
 	})
 	if err != nil {
-		return false, nil, fmt.Errorf("failed to push changes to git repository %s: %w", s.Repository.FullName(), err)
+		return false, existingPR, fmt.Errorf("failed to push changes to git repository %s: %w", s.Repository.FullName(), err)
 	}
 
 	var pr *github.PullRequest
@@ -90,7 +90,7 @@ func (s *ResetStrategy) Run(ctx context.Context) (bool, *github.PullRequest, err
 		pr, err = s.Repository.createPullRequest(ctx, s.Options.GitHub, branchName)
 	}
 	if err != nil {
-		return false, nil, fmt.Errorf("failed to create or update Pull Request: %w", err)
+		return false, existingPR, fmt.Errorf("failed to create or update Pull Request: %w", err)
 	}
 
 	return true, pr, nil


### PR DESCRIPTION
I've put it as a feature because it changes the behavior of octopilot

Let's take as example a repository where the PR is unrevised (the PR already exist, not yet merged and doesn't need new update)
```
INFO[0001] Updates finished                              repositories-count=1
INFO[0001] Update summary (Unrevised)                    unrevised-repository-count=1
INFO[0001] Update summary (Unrevised)                    unrevised-repository-pr-url="https://github.com/xxx/yyy/pull/777"
```

Let's take as example a repository where the PR is created / updated by octopilot
```
INFO[0001] Updates finished                            repositories-count=1
INFO[0001] Update summary (Updated)                    updated-repository-count=1
INFO[0001] Update summary (Updated)                    updated-repository-pr-url="https://github.com/xxx/yyy/pull/888"
```

For instance in dry-run you will be able to see already opened PR that doesn't need new changes compare to the one you want to apply.

```
WARN[0173] Running in dry-run mode, not pushing changes  repository=a/z

INFO[0173] Updates finished                              repositories-count=5
INFO[0173] Update summary (Unrevised)                    unrevised-repository-count=3
INFO[0173] Update summary (Unrevised)                    unrevised-repository-pr-url="https://github.com/a/b/pull/5"
INFO[0173] Update summary (Unrevised)                    unrevised-repository-pr-url="https://github.com/a/c/pull/41"
INFO[0173] Update summary (Unrevised)                    unrevised-repository-pr-url="https://github.com/a/d/pull/7"
```

It's also easier this way to list all the pullrequests and order them by type (unrevised vs updated)