### PR TITLE
refactor: refactoring introducing a single generic strategy

### DIFF
--- a/repository/commit.go
+++ b/repository/commit.go
@@ -1,0 +1,39 @@
+package repository
+
+import (
+	"strings"
+)
+
+type CommitMessage struct {
+	Headline string
+	Body     string
+}
+
+func (c CommitMessage) String() string {
+	commitMsg := new(strings.Builder)
+	commitMsg.WriteString(c.Headline)
+	if len(c.Body) > 0 {
+		commitMsg.WriteString("\n\n")
+		commitMsg.WriteString(c.Body)
+	}
+	return commitMsg.String()
+}
+
+func NewCommitMessage(title, body, footer string) CommitMessage {
+	bodyWithFooter := new(strings.Builder)
+	if len(body) > 0 {
+		bodyWithFooter.WriteString(body)
+	}
+	if len(footer) > 0 {
+		if bodyWithFooter.Len() > 0 {
+			bodyWithFooter.WriteString("\n\n")
+		}
+		bodyWithFooter.WriteString("-- \n")
+		bodyWithFooter.WriteString(footer)
+	}
+
+	return CommitMessage{
+		Headline: title,
+		Body:     bodyWithFooter.String(),
+	}
+}

--- a/repository/commit_test.go
+++ b/repository/commit_test.go
@@ -1,0 +1,56 @@
+package repository
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		title    string
+		body     string
+		footer   string
+		expected string
+	}{
+		{
+			name:     "No content",
+			expected: "",
+		},
+		{
+			name:     "Only title",
+			title:    "title",
+			expected: "title",
+		},
+		{
+			name:     "Title and body",
+			title:    "title",
+			body:     "body\nbody",
+			expected: "title\n\nbody\nbody",
+		},
+		{
+			name:     "Title and footer",
+			title:    "title",
+			footer:   "footer\nfooter",
+			expected: "title\n\n-- \nfooter\nfooter",
+		},
+		{
+			name:     "Title body and footer",
+			title:    "title",
+			body:     "body\nbody",
+			footer:   "footer\nfooter",
+			expected: "title\n\nbody\nbody\n\n-- \nfooter\nfooter",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			commitMessage := NewCommitMessage(test.title, test.body, test.footer)
+			actual := commitMessage.String()
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}

--- a/repository/git.go
+++ b/repository/git.go
@@ -107,14 +107,11 @@ func switchBranch(_ context.Context, gitRepo *git.Repository, opts switchBranchO
 	return nil
 }
 
-func commitChanges(_ context.Context, gitRepo *git.Repository, options UpdateOptions) (bool, error) {
+func commitChanges(_ context.Context, repository Repository, gitRepo *git.Repository, options UpdateOptions) (bool, error) {
 	workTree, err := gitRepo.Worktree()
 	if err != nil {
 		return false, fmt.Errorf("failed to open worktree: %w", err)
 	}
-
-	rootPath := workTree.Filesystem.Root()
-	repoName := filepath.Base(rootPath)
 
 	status, err := workTree.Status()
 	if err != nil {
@@ -124,8 +121,8 @@ func commitChanges(_ context.Context, gitRepo *git.Repository, options UpdateOpt
 		return false, nil
 	}
 	logrus.WithFields(logrus.Fields{
-		"repository-name": repoName,
-		"status":          status.String(),
+		"repository": repository.FullName(),
+		"status":     status.String(),
 	}).Debug("Git status")
 
 	for _, pattern := range options.Git.StagePatterns {
@@ -172,8 +169,8 @@ func commitChanges(_ context.Context, gitRepo *git.Repository, options UpdateOpt
 		return false, fmt.Errorf("failed to commit: %w", err)
 	}
 	logrus.WithFields(logrus.Fields{
-		"repository-name": repoName,
-		"commit":          commit.String(),
+		"repository": repository.FullName(),
+		"commit":     commit.String(),
 	}).Debug("Git commit")
 
 	return true, nil

--- a/repository/git.go
+++ b/repository/git.go
@@ -136,22 +136,15 @@ func commitChanges(_ context.Context, gitRepo *git.Repository, opts commitOption
 		}
 	}
 
-	now := time.Now()
-	commitMsg := new(strings.Builder)
-	commitMsg.WriteString(opts.GitOpts.CommitTitle)
-	if len(opts.GitOpts.CommitBody) > 0 {
-		commitMsg.WriteString("\n\n")
-		commitMsg.WriteString(opts.GitOpts.CommitBody)
-	}
-	if len(opts.GitOpts.CommitFooter) > 0 {
-		commitMsg.WriteString("\n\n-- \n")
-		commitMsg.WriteString(opts.GitOpts.CommitFooter)
-	}
-
 	signingKey, err := parseSigningKey(opts.GitOpts.SigningKeyPath, opts.GitOpts.SigningKeyPassphrase)
 	if err != nil {
 		return false, err
 	}
+
+	var (
+		now = time.Now()
+		commitMsg = NewCommitMessage(opts.GitOpts.CommitTitle, opts.GitOpts.CommitBody, opts.GitOpts.CommitFooter)
+	)
 
 	commit, err := workTree.Commit(commitMsg.String(),
 		&git.CommitOptions{

--- a/repository/git.go
+++ b/repository/git.go
@@ -199,15 +199,15 @@ func parseSigningKey(signingKeyPath, signingKeyPassphrase string) (*openpgp.Enti
 }
 
 type pushOptions struct {
-	GitHubOpts GitHubOptions
-	Repository Repository
-	BranchName string
-	ForcePush  bool
+	GitHubOpts    GitHubOptions
+	Repository    Repository
+	BranchName    string
+	ResetFromBase bool
 }
 
 func pushChanges(ctx context.Context, gitRepo *git.Repository, opts pushOptions) error {
 	refSpec := fmt.Sprintf("refs/heads/%[1]s:refs/heads/%[1]s", opts.BranchName)
-	if opts.ForcePush {
+	if opts.ResetFromBase {
 		// https://git-scm.com/book/en/v2/Git-Internals-The-Refspec
 		// The + tells Git to update the reference even if it isn’t a fast-forward.
 		refSpec = fmt.Sprintf("+%s", refSpec)
@@ -221,7 +221,7 @@ func pushChanges(ctx context.Context, gitRepo *git.Repository, opts pushOptions)
 	logrus.WithFields(logrus.Fields{
 		"repository": opts.Repository.FullName(),
 		"branch":     opts.BranchName,
-		"force":      opts.ForcePush,
+		"force":      opts.ResetFromBase,
 	}).Trace("Pushing git changes")
 	err = gitRepo.PushContext(ctx, &git.PushOptions{
 		RefSpecs: []config.RefSpec{

--- a/repository/git.go
+++ b/repository/git.go
@@ -107,8 +107,9 @@ func switchBranch(_ context.Context, gitRepo *git.Repository, opts switchBranchO
 }
 
 type commitOptions struct {
-	Repository Repository
-	GitOpts    GitOptions
+	Repository    Repository
+	CommitMessage CommitMessage
+	GitOpts       GitOptions
 }
 
 func commitChanges(_ context.Context, gitRepo *git.Repository, opts commitOptions) (bool, error) {
@@ -141,12 +142,9 @@ func commitChanges(_ context.Context, gitRepo *git.Repository, opts commitOption
 		return false, err
 	}
 
-	var (
-		now = time.Now()
-		commitMsg = NewCommitMessage(opts.GitOpts.CommitTitle, opts.GitOpts.CommitBody, opts.GitOpts.CommitFooter)
-	)
+	now := time.Now()
 
-	commit, err := workTree.Commit(commitMsg.String(),
+	commit, err := workTree.Commit(opts.CommitMessage.String(),
 		&git.CommitOptions{
 			All: opts.GitOpts.StageAllChanged,
 			Author: &object.Signature{

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -122,38 +122,23 @@ func (r Repository) Update(ctx context.Context, updaters []update.Updater, optio
 		}()
 	}
 
-	var strategy Strategy
+	var strategy *Strategy
 	switch options.Strategy {
 	case "recreate":
 		logrus.WithFields(logrus.Fields{
 			"repository": r.FullName(),
 		}).Debug("Using 'recreate' strategy")
-		strategy = &RecreateStrategy{
-			Repository: r,
-			RepoPath:   repoPath,
-			Updaters:   updaters,
-			Options:    options,
-		}
+		strategy = NewRecreateStrategy(r, repoPath, updaters, options)
 	case "append":
 		logrus.WithFields(logrus.Fields{
 			"repository": r.FullName(),
 		}).Debug("Using 'append' strategy")
-		strategy = &AppendStrategy{
-			Repository: r,
-			RepoPath:   repoPath,
-			Updaters:   updaters,
-			Options:    options,
-		}
+		strategy = NewAppendStrategy(r, repoPath, updaters, options)
 	default:
 		logrus.WithFields(logrus.Fields{
 			"repository": r.FullName(),
 		}).Debug("Using 'reset' strategy")
-		strategy = &ResetStrategy{
-			Repository: r,
-			RepoPath:   repoPath,
-			Updaters:   updaters,
-			Options:    options,
-		}
+		strategy = NewResetStrategy(r, repoPath, updaters, options)
 	}
 
 	repoUpdated, pr, err := strategy.Run(ctx)

--- a/repository/strategy.go
+++ b/repository/strategy.go
@@ -50,6 +50,7 @@ func (s *Strategy) Run(ctx context.Context) (bool, *github.PullRequest, error) {
 		branchName = s.Repository.newBranchName(s.Options.Git.BranchPrefix)
 	}
 	err = switchBranch(ctx, gitRepo, switchBranchOptions{
+		Repository:   s.Repository,
 		BranchName:   branchName,
 		CreateBranch: s.ForceBranchCreation || existingPR == nil,
 	})

--- a/repository/strategy.go
+++ b/repository/strategy.go
@@ -17,8 +17,7 @@ type Strategy struct {
 	Options                 UpdateOptions
 	FindMatchingPullRequest bool
 	DefaultUpdateOperation  string
-	ForcePush               bool
-	ForceBranchCreation     bool
+	ResetFromBase           bool
 }
 
 // Run executes the strategy. It returns:
@@ -52,7 +51,7 @@ func (s *Strategy) Run(ctx context.Context) (bool, *github.PullRequest, error) {
 	err = switchBranch(ctx, gitRepo, switchBranchOptions{
 		Repository:   s.Repository,
 		BranchName:   branchName,
-		CreateBranch: s.ForceBranchCreation || existingPR == nil,
+		CreateBranch: s.ResetFromBase || existingPR == nil,
 	})
 	if err != nil {
 		return false, existingPR, fmt.Errorf("failed to switch to branch %s: %w", branchName, err)
@@ -96,10 +95,10 @@ func (s *Strategy) Run(ctx context.Context) (bool, *github.PullRequest, error) {
 	}
 
 	err = pushChanges(ctx, gitRepo, pushOptions{
-		GitHubOpts: s.Options.GitHub,
-		Repository: s.Repository,
-		BranchName: branchName,
-		ForcePush:  s.ForcePush,
+		GitHubOpts:    s.Options.GitHub,
+		Repository:    s.Repository,
+		BranchName:    branchName,
+		ResetFromBase: s.ResetFromBase,
 	})
 	if err != nil {
 		return false, existingPR, fmt.Errorf("failed to push changes to git repository %s: %w", s.Repository.FullName(), err)

--- a/repository/strategy.go
+++ b/repository/strategy.go
@@ -76,7 +76,7 @@ func (s *Strategy) Run(ctx context.Context) (bool, *github.PullRequest, error) {
 		s.Options.GitHub.setDefaultUpdateOperation(IgnoreUpdateOperation)
 	}
 
-	changesCommitted, err := commitChanges(ctx, gitRepo, s.Options)
+	changesCommitted, err := commitChanges(ctx, s.Repository, gitRepo, s.Options)
 	if err != nil {
 		return false, existingPR, fmt.Errorf("failed to commit changes to git repository %s: %w", s.Repository.FullName(), err)
 	}

--- a/repository/strategy.go
+++ b/repository/strategy.go
@@ -2,14 +2,110 @@ package repository
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/dailymotion-oss/octopilot/update"
 	"github.com/google/go-github/v57/github"
+	"github.com/sirupsen/logrus"
 )
 
 // Strategy defines how the pull request will be created or updated if one already exists.
-type Strategy interface {
-	// Run executes the strategy. It returns:
-	// - a boolean indicating whether changes have been made to the repository
-	// - a pull request if one has been created (or updated)
-	Run(context.Context) (bool, *github.PullRequest, error)
+type Strategy struct {
+	Repository              Repository
+	RepoPath                string
+	Updaters                []update.Updater
+	Options                 UpdateOptions
+	FindMatchingPullRequest bool
+	DefaultUpdateOperation  string
+	ForcePush               bool
+	ForceBranchCreation     bool
+}
+
+// Run executes the strategy. It returns:
+// - a boolean indicating whether changes have been made to the repository
+// - a pull request if one has been created (or updated)
+func (s *Strategy) Run(ctx context.Context) (bool, *github.PullRequest, error) {
+	gitRepo, err := cloneGitRepository(ctx, s.Repository, s.RepoPath, s.Options.GitHub)
+	if err != nil {
+		return false, nil, fmt.Errorf("failed to clone repository %s: %w", s.Repository.FullName(), err)
+	}
+
+	err = s.Options.GitHub.adjustOptionsFromGitRepository(gitRepo)
+	if err != nil {
+		return false, nil, fmt.Errorf("failed to adjust options for repository %s: %w", s.Repository.FullName(), err)
+	}
+
+	var existingPR *github.PullRequest
+	if s.FindMatchingPullRequest {
+		existingPR, err = s.Repository.findMatchingPullRequest(ctx, s.Options.GitHub)
+		if err != nil {
+			return false, nil, fmt.Errorf("failed to find matching pull request for repository %s: %w", s.Repository.FullName(), err)
+		}
+	}
+
+	var branchName string
+	if existingPR != nil {
+		branchName = existingPR.Head.GetRef()
+	} else {
+		branchName = s.Repository.newBranchName(s.Options.Git.BranchPrefix)
+	}
+	err = switchBranch(ctx, gitRepo, switchBranchOptions{
+		BranchName:   branchName,
+		CreateBranch: s.ForceBranchCreation || existingPR == nil,
+	})
+	if err != nil {
+		return false, existingPR, fmt.Errorf("failed to switch to branch %s: %w", branchName, err)
+	}
+
+	repoUpdated, err := s.Repository.runUpdaters(ctx, s.Updaters, s.RepoPath)
+	if err != nil {
+		return false, existingPR, fmt.Errorf("failed to update repository %s: %w", s.Repository.FullName(), err)
+	}
+	if !repoUpdated {
+		return false, existingPR, nil
+	}
+
+	if err = s.Options.Git.setDefaultValues(s.Updaters, templateExecutorFor(s.Options, s.Repository, s.RepoPath)); err != nil {
+		return false, existingPR, fmt.Errorf("failed to set default git values: %w", err)
+	}
+	if err = s.Options.GitHub.setDefaultValues(s.Options.Git, templateExecutorFor(s.Options, s.Repository, s.RepoPath)); err != nil {
+		return false, existingPR, fmt.Errorf("failed to set default github values: %w", err)
+	}
+	if len(s.DefaultUpdateOperation) > 0 {
+		s.Options.GitHub.setDefaultUpdateOperation(IgnoreUpdateOperation)
+	}
+
+	changesCommitted, err := commitChanges(ctx, gitRepo, s.Options)
+	if err != nil {
+		return false, existingPR, fmt.Errorf("failed to commit changes to git repository %s: %w", s.Repository.FullName(), err)
+	}
+	if !changesCommitted {
+		logrus.WithField("repository", s.Repository.FullName()).Debug("No changes recorded, nothing to push")
+		return false, existingPR, nil
+	}
+	if s.Options.DryRun {
+		logrus.WithField("repository", s.Repository.FullName()).Warning("Running in dry-run mode, not pushing changes")
+		return false, existingPR, nil
+	}
+
+	err = pushChanges(ctx, gitRepo, pushOptions{
+		GitHubOpts: s.Options.GitHub,
+		BranchName: branchName,
+		ForcePush:  s.ForcePush,
+	})
+	if err != nil {
+		return false, existingPR, fmt.Errorf("failed to push changes to git repository %s: %w", s.Repository.FullName(), err)
+	}
+
+	var pr *github.PullRequest
+	if existingPR != nil {
+		pr, err = s.Repository.updatePullRequest(ctx, s.Options.GitHub, existingPR)
+	} else {
+		pr, err = s.Repository.createPullRequest(ctx, s.Options.GitHub, branchName)
+	}
+	if err != nil {
+		return false, existingPR, fmt.Errorf("failed to create or update Pull Request: %w", err)
+	}
+
+	return true, pr, nil
 }

--- a/repository/strategy.go
+++ b/repository/strategy.go
@@ -76,9 +76,12 @@ func (s *Strategy) Run(ctx context.Context) (bool, *github.PullRequest, error) {
 		s.Options.GitHub.setDefaultUpdateOperation(IgnoreUpdateOperation)
 	}
 
+	commitMessage := NewCommitMessage(s.Options.Git.CommitTitle, s.Options.Git.CommitBody, s.Options.Git.CommitFooter)
+
 	changesCommitted, err := commitChanges(ctx, gitRepo, commitOptions{
-		Repository: s.Repository,
-		GitOpts:    s.Options.Git,
+		Repository:    s.Repository,
+		CommitMessage: commitMessage,
+		GitOpts:       s.Options.Git,
 	})
 	if err != nil {
 		return false, existingPR, fmt.Errorf("failed to commit changes to git repository %s: %w", s.Repository.FullName(), err)

--- a/repository/strategy.go
+++ b/repository/strategy.go
@@ -94,6 +94,7 @@ func (s *Strategy) Run(ctx context.Context) (bool, *github.PullRequest, error) {
 
 	err = pushChanges(ctx, gitRepo, pushOptions{
 		GitHubOpts: s.Options.GitHub,
+		Repository: s.Repository,
 		BranchName: branchName,
 		ForcePush:  s.ForcePush,
 	})

--- a/repository/strategy.go
+++ b/repository/strategy.go
@@ -76,7 +76,10 @@ func (s *Strategy) Run(ctx context.Context) (bool, *github.PullRequest, error) {
 		s.Options.GitHub.setDefaultUpdateOperation(IgnoreUpdateOperation)
 	}
 
-	changesCommitted, err := commitChanges(ctx, s.Repository, gitRepo, s.Options)
+	changesCommitted, err := commitChanges(ctx, gitRepo, commitOptions{
+		Repository: s.Repository,
+		GitOpts:    s.Options.Git,
+	})
 	if err != nil {
 		return false, existingPR, fmt.Errorf("failed to commit changes to git repository %s: %w", s.Repository.FullName(), err)
 	}

--- a/repository/strategy_append.go
+++ b/repository/strategy_append.go
@@ -14,7 +14,6 @@ func NewAppendStrategy(repository Repository, repoPath string, updaters []update
 		Options:                 options,
 		FindMatchingPullRequest: true,
 		DefaultUpdateOperation:  IgnoreUpdateOperation,
-		ForcePush:               false,
-		ForceBranchCreation:     false,
+		ResetFromBase:           false,
 	}
 }

--- a/repository/strategy_append.go
+++ b/repository/strategy_append.go
@@ -1,103 +1,20 @@
 package repository
 
 import (
-	"context"
-	"fmt"
-
 	"github.com/dailymotion-oss/octopilot/update"
-	"github.com/google/go-github/v57/github"
-	"github.com/sirupsen/logrus"
 )
 
-// AppendStrategy is a strategy implementation that appends new commits to any existing Pull Request.
+// AppendStrategy is a strategy that appends new commits to any existing Pull Request.
 // So it will try to find a matching PR first, and use it (its branch). Then it will commit on this branch, and update the existing PR - or create a new one if there is no matching PR.
-type AppendStrategy struct {
-	Repository Repository
-	RepoPath   string
-	Updaters   []update.Updater
-	Options    UpdateOptions
-}
-
-// Run executes the strategy, and returns true if the repo was updated, and the created/updated PR.
-func (s *AppendStrategy) Run(ctx context.Context) (bool, *github.PullRequest, error) {
-	gitRepo, err := cloneGitRepository(ctx, s.Repository, s.RepoPath, s.Options.GitHub)
-	if err != nil {
-		return false, nil, fmt.Errorf("failed to clone repository %s: %w", s.Repository.FullName(), err)
+func NewAppendStrategy(repository Repository, repoPath string, updaters []update.Updater, options UpdateOptions) *Strategy {
+	return &Strategy{
+		Repository:              repository,
+		RepoPath:                repoPath,
+		Updaters:                updaters,
+		Options:                 options,
+		FindMatchingPullRequest: true,
+		DefaultUpdateOperation:  IgnoreUpdateOperation,
+		ForcePush:               false,
+		ForceBranchCreation:     false,
 	}
-
-	err = s.Options.GitHub.adjustOptionsFromGitRepository(gitRepo)
-	if err != nil {
-		return false, nil, fmt.Errorf("failed to adjust options for repository %s: %w", s.Repository.FullName(), err)
-	}
-
-	existingPR, err := s.Repository.findMatchingPullRequest(ctx, s.Options.GitHub)
-	if err != nil {
-		return false, nil, fmt.Errorf("failed to find matching pull request for repository %s: %w", s.Repository.FullName(), err)
-	}
-
-	var branchName string
-	if existingPR != nil {
-		branchName = existingPR.Head.GetRef()
-		err = switchBranch(ctx, gitRepo, switchBranchOptions{
-			BranchName: branchName,
-		})
-	} else {
-		branchName = s.Repository.newBranchName(s.Options.Git.BranchPrefix)
-		err = switchBranch(ctx, gitRepo, switchBranchOptions{
-			BranchName:   branchName,
-			CreateBranch: true,
-		})
-	}
-	if err != nil {
-		return false, existingPR, fmt.Errorf("failed to switch to branch %s: %w", branchName, err)
-	}
-
-	repoUpdated, err := s.Repository.runUpdaters(ctx, s.Updaters, s.RepoPath)
-	if err != nil {
-		return false, existingPR, fmt.Errorf("failed to update repository %s: %w", s.Repository.FullName(), err)
-	}
-	if !repoUpdated {
-		return false, existingPR, nil
-	}
-
-	if err = s.Options.Git.setDefaultValues(s.Updaters, templateExecutorFor(s.Options, s.Repository, s.RepoPath)); err != nil {
-		return false, existingPR, fmt.Errorf("failed to set default git values: %w", err)
-	}
-	if err = s.Options.GitHub.setDefaultValues(s.Options.Git, templateExecutorFor(s.Options, s.Repository, s.RepoPath)); err != nil {
-		return false, existingPR, fmt.Errorf("failed to set default github values: %w", err)
-	}
-	s.Options.GitHub.setDefaultUpdateOperation(IgnoreUpdateOperation)
-
-	changesCommitted, err := commitChanges(ctx, gitRepo, s.Options)
-	if err != nil {
-		return false, existingPR, fmt.Errorf("failed to commit changes to git repository %s: %w", s.Repository.FullName(), err)
-	}
-	if !changesCommitted {
-		logrus.WithField("repository", s.Repository.FullName()).Debug("No changes recorded, nothing to push")
-		return false, existingPR, nil
-	}
-	if s.Options.DryRun {
-		logrus.WithField("repository", s.Repository.FullName()).Warning("Running in dry-run mode, not pushing changes")
-		return false, existingPR, nil
-	}
-
-	err = pushChanges(ctx, gitRepo, pushOptions{
-		GitHubOpts: s.Options.GitHub,
-		BranchName: branchName,
-	})
-	if err != nil {
-		return false, existingPR, fmt.Errorf("failed to push changes to git repository %s: %w", s.Repository.FullName(), err)
-	}
-
-	var pr *github.PullRequest
-	if existingPR != nil {
-		pr, err = s.Repository.updatePullRequest(ctx, s.Options.GitHub, existingPR)
-	} else {
-		pr, err = s.Repository.createPullRequest(ctx, s.Options.GitHub, branchName)
-	}
-	if err != nil {
-		return false, existingPR, fmt.Errorf("failed to create or update Pull Request: %w", err)
-	}
-
-	return true, pr, nil
 }

--- a/repository/strategy_recreate.go
+++ b/repository/strategy_recreate.go
@@ -13,7 +13,6 @@ func NewRecreateStrategy(repository Repository, repoPath string, updaters []upda
 		Options:                 options,
 		FindMatchingPullRequest: false,
 		DefaultUpdateOperation:  "",
-		ForcePush:               false,
-		ForceBranchCreation:     false,
+		ResetFromBase:           false,
 	}
 }

--- a/repository/strategy_recreate.go
+++ b/repository/strategy_recreate.go
@@ -1,83 +1,19 @@
 package repository
 
 import (
-	"context"
-	"fmt"
-
 	"github.com/dailymotion-oss/octopilot/update"
-	"github.com/google/go-github/v57/github"
-	"github.com/sirupsen/logrus"
 )
 
 // RecreateStrategy is a strategy implementation that always creates a new Pull Request - even if an existing one for the same labels already exists.
-type RecreateStrategy struct {
-	Repository Repository
-	RepoPath   string
-	Updaters   []update.Updater
-	Options    UpdateOptions
-}
-
-// Run executes the strategy, and returns true if the repo was updated, and the created PR.
-func (s *RecreateStrategy) Run(ctx context.Context) (bool, *github.PullRequest, error) {
-	gitRepo, err := cloneGitRepository(ctx, s.Repository, s.RepoPath, s.Options.GitHub)
-	if err != nil {
-		return false, nil, fmt.Errorf("failed to clone repository %s: %w", s.Repository.FullName(), err)
+func NewRecreateStrategy(repository Repository, repoPath string, updaters []update.Updater, options UpdateOptions) *Strategy {
+	return &Strategy{
+		Repository:              repository,
+		RepoPath:                repoPath,
+		Updaters:                updaters,
+		Options:                 options,
+		FindMatchingPullRequest: false,
+		DefaultUpdateOperation:  "",
+		ForcePush:               false,
+		ForceBranchCreation:     false,
 	}
-
-	err = s.Options.GitHub.adjustOptionsFromGitRepository(gitRepo)
-	if err != nil {
-		return false, nil, fmt.Errorf("failed to adjust options for repository %s: %w", s.Repository.FullName(), err)
-	}
-
-	branchName := s.Repository.newBranchName(s.Options.Git.BranchPrefix)
-	err = switchBranch(ctx, gitRepo, switchBranchOptions{
-		BranchName:   branchName,
-		CreateBranch: true,
-	})
-	if err != nil {
-		return false, nil, fmt.Errorf("failed to switch to branch %s: %w", branchName, err)
-	}
-
-	repoUpdated, err := s.Repository.runUpdaters(ctx, s.Updaters, s.RepoPath)
-	if err != nil {
-		return false, nil, fmt.Errorf("failed to update repository %s: %w", s.Repository.FullName(), err)
-	}
-	if !repoUpdated {
-		return false, nil, nil
-	}
-
-	if err = s.Options.Git.setDefaultValues(s.Updaters, templateExecutorFor(s.Options, s.Repository, s.RepoPath)); err != nil {
-		return false, nil, fmt.Errorf("failed to set default git values: %w", err)
-	}
-	if err = s.Options.GitHub.setDefaultValues(s.Options.Git, templateExecutorFor(s.Options, s.Repository, s.RepoPath)); err != nil {
-		return false, nil, fmt.Errorf("failed to set default github values: %w", err)
-	}
-
-	changesCommitted, err := commitChanges(ctx, gitRepo, s.Options)
-	if err != nil {
-		return false, nil, fmt.Errorf("failed to commit changes to git repository %s: %w", s.Repository.FullName(), err)
-	}
-	if !changesCommitted {
-		logrus.WithField("repository", s.Repository.FullName()).Debug("No changes recorded, nothing to push")
-		return false, nil, nil
-	}
-	if s.Options.DryRun {
-		logrus.WithField("repository", s.Repository.FullName()).Warning("Running in dry-run mode, not pushing changes")
-		return false, nil, nil
-	}
-
-	err = pushChanges(ctx, gitRepo, pushOptions{
-		GitHubOpts: s.Options.GitHub,
-		BranchName: branchName,
-	})
-	if err != nil {
-		return false, nil, fmt.Errorf("failed to push changes to git repository %s: %w", s.Repository.FullName(), err)
-	}
-
-	pr, err := s.Repository.createPullRequest(ctx, s.Options.GitHub, branchName)
-	if err != nil {
-		return false, nil, fmt.Errorf("failed to create Pull Request: %w", err)
-	}
-
-	return true, pr, nil
 }

--- a/repository/strategy_reset.go
+++ b/repository/strategy_reset.go
@@ -1,102 +1,20 @@
 package repository
 
 import (
-	"context"
-	"fmt"
-
 	"github.com/dailymotion-oss/octopilot/update"
-	"github.com/google/go-github/v57/github"
-	"github.com/sirupsen/logrus"
 )
 
 // ResetStrategy is a strategy implementation that resets any existing Pull Request from the base branch.
 // So it will try to find a matching PR first, and use it (its branch) - but it will "reset" the branch from the base branch. And it will update the existing PR - or create a new one.
-type ResetStrategy struct {
-	Repository Repository
-	RepoPath   string
-	Updaters   []update.Updater
-	Options    UpdateOptions
-}
-
-// Run executes the strategy, and returns true if the repo was updated, and the created/updated PR.
-func (s *ResetStrategy) Run(ctx context.Context) (bool, *github.PullRequest, error) {
-	gitRepo, err := cloneGitRepository(ctx, s.Repository, s.RepoPath, s.Options.GitHub)
-	if err != nil {
-		return false, nil, fmt.Errorf("failed to clone repository %s: %w", s.Repository.FullName(), err)
+func NewResetStrategy(repository Repository, repoPath string, updaters []update.Updater, options UpdateOptions) *Strategy {
+	return &Strategy{
+		Repository:              repository,
+		RepoPath:                repoPath,
+		Updaters:                updaters,
+		Options:                 options,
+		FindMatchingPullRequest: true,
+		DefaultUpdateOperation:  ReplaceUpdateOperation,
+		ForcePush:               true,
+		ForceBranchCreation:     true,
 	}
-
-	err = s.Options.GitHub.adjustOptionsFromGitRepository(gitRepo)
-	if err != nil {
-		return false, nil, fmt.Errorf("failed to adjust options for repository %s: %w", s.Repository.FullName(), err)
-	}
-
-	existingPR, err := s.Repository.findMatchingPullRequest(ctx, s.Options.GitHub)
-	if err != nil {
-		return false, nil, fmt.Errorf("failed to find matching pull request for repository %s: %w", s.Repository.FullName(), err)
-	}
-
-	var branchName string
-	if existingPR != nil {
-		branchName = existingPR.Head.GetRef()
-	} else {
-		branchName = s.Repository.newBranchName(s.Options.Git.BranchPrefix)
-	}
-
-	err = switchBranch(ctx, gitRepo, switchBranchOptions{
-		BranchName:   branchName,
-		CreateBranch: true,
-	})
-	if err != nil {
-		return false, existingPR, fmt.Errorf("failed to switch to branch %s: %w", branchName, err)
-	}
-
-	repoUpdated, err := s.Repository.runUpdaters(ctx, s.Updaters, s.RepoPath)
-	if err != nil {
-		return false, existingPR, fmt.Errorf("failed to update repository %s: %w", s.Repository.FullName(), err)
-	}
-	if !repoUpdated {
-		return false, existingPR, nil
-	}
-
-	if err = s.Options.Git.setDefaultValues(s.Updaters, templateExecutorFor(s.Options, s.Repository, s.RepoPath)); err != nil {
-		return false, existingPR, fmt.Errorf("failed to set default git values: %w", err)
-	}
-	if err = s.Options.GitHub.setDefaultValues(s.Options.Git, templateExecutorFor(s.Options, s.Repository, s.RepoPath)); err != nil {
-		return false, existingPR, fmt.Errorf("failed to set default github values: %w", err)
-	}
-	s.Options.GitHub.setDefaultUpdateOperation(ReplaceUpdateOperation)
-
-	changesCommitted, err := commitChanges(ctx, gitRepo, s.Options)
-	if err != nil {
-		return false, existingPR, fmt.Errorf("failed to commit changes to git repository %s: %w", s.Repository.FullName(), err)
-	}
-	if !changesCommitted {
-		logrus.WithField("repository", s.Repository.FullName()).Debug("No changes recorded, nothing to push")
-		return false, existingPR, nil
-	}
-	if s.Options.DryRun {
-		logrus.WithField("repository", s.Repository.FullName()).Warning("Running in dry-run mode, not pushing changes")
-		return false, existingPR, nil
-	}
-
-	err = pushChanges(ctx, gitRepo, pushOptions{
-		GitHubOpts: s.Options.GitHub,
-		BranchName: branchName,
-		ForcePush:  true,
-	})
-	if err != nil {
-		return false, existingPR, fmt.Errorf("failed to push changes to git repository %s: %w", s.Repository.FullName(), err)
-	}
-
-	var pr *github.PullRequest
-	if existingPR != nil {
-		pr, err = s.Repository.updatePullRequest(ctx, s.Options.GitHub, existingPR)
-	} else {
-		pr, err = s.Repository.createPullRequest(ctx, s.Options.GitHub, branchName)
-	}
-	if err != nil {
-		return false, existingPR, fmt.Errorf("failed to create or update Pull Request: %w", err)
-	}
-
-	return true, pr, nil
 }

--- a/repository/strategy_reset.go
+++ b/repository/strategy_reset.go
@@ -14,7 +14,6 @@ func NewResetStrategy(repository Repository, repoPath string, updaters []update.
 		Options:                 options,
 		FindMatchingPullRequest: true,
 		DefaultUpdateOperation:  ReplaceUpdateOperation,
-		ForcePush:               true,
-		ForceBranchCreation:     true,
+		ResetFromBase:           true,
 	}
 }


### PR DESCRIPTION
The goal of this PR is to refactor the implementation of the strategies to move from an interface with an implementation dedicated to each strategy to a generic strategy whose behaviour is defined according to its options.

This refactoring should reduces the code duplication and ease maintenance and the addition of new feature.

Note: I tried to create unit commits to make it easier to review pull request commit by commit.