### PR TITLE
ci(setup-go): upgrade `setup-go` to 5.0.2

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -13,7 +13,7 @@ jobs:
         run: git fetch --prune --unshallow
 
       - name: Setup Go
-        uses: actions/setup-go@v4.1.0
+        uses: actions/setup-go@v5.0.2
         with:
           go-version-file: 'go.mod'
 

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Go
-        uses: actions/setup-go@v4.1.0
+        uses: actions/setup-go@v5.0.2
         with:
           go-version-file: 'go.mod'
 


### PR DESCRIPTION
## Description

This PR upgrades `setup-go` GitHub Action to 5.0.2.

Changelog: https://github.com/actions/setup-go?tab=readme-ov-file#v5, it should be safe.