### PR TITLE
docs: github auth method flag instead of token

### DIFF
--- a/docs/current-version/content/github/_index.md
+++ b/docs/current-version/content/github/_index.md
@@ -17,7 +17,7 @@ You can define which method to use, using the `--github-auth-method` CLI flag.
 
 ## Personal Access Token
 
-By default, the `--github-auth-token` flag is set to `token`, so Octopilot will use a **Personal Access Token** - or `PAT`. This token can be defined either by the `GITHUB_TOKEN` environment variable, or by setting the `--github-token` CLI flag.
+By default, the `--github-auth-method` flag is set to `token`, so Octopilot will use a **Personal Access Token** - or `PAT`. This token can be defined either by the `GITHUB_TOKEN` environment variable, or by setting the `--github-token` CLI flag.
 
 You can read GitHub's documentation on [creating a personal access token](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token). You'll need at least the `repo` permissions.
 
@@ -25,7 +25,7 @@ You can read GitHub's documentation on [creating a personal access token](https:
 
 An alternative to the "simple" token is to use a [GitHub App](https://docs.github.com/en/developers/apps).
 
-First, you'll need to set the `--github-auth-token` flag value to `app`, and then configure the following settings:
+First, you'll need to set the `--github-auth-method` flag value to `app`, and then configure the following settings:
 - `--github-app-id` (int): the GitHub App ID. Default to the value of the `GITHUB_APP_ID` environment variable.
 - `--github-installation-id` (int): the GitHub App installation ID. Default to the value of the `GITHUB_INSTALLATION_ID` environment variable.
 - `--github-privatekey` (string): the app's private key - used to sign access token requests - in PEM format. Default to the value of the `GITHUB_PRIVATEKEY` environment variable. You can either set this, or the `--github-privatekey-path`.


### PR DESCRIPTION
The documentation incorrectly states the `--github-auth-token` flag should be used to change github auth type, when the correct flag is `--github-auth-method`.