### PR TITLE
fix: submodule updates & reset strategy w/ Github App

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,6 +39,8 @@ linters-settings:
   nolintlint:
     require-specific: true
     require-explanation: true
+  exhaustive:
+    default-signifies-exhaustive: true
   revive:
     #enable-all-rules: true
     rules:

--- a/repository/git.go
+++ b/repository/git.go
@@ -280,7 +280,6 @@ func stageSubmodules(ctx context.Context, repo *git.Repository, opts *GitOptions
 			return fmt.Errorf("failed to get submodule %s index entry: %w", s.Config().Name, err)
 		}
 		entry.Hash = status.Current
-
 	}
 
 	err = repo.Storer.SetIndex(index)

--- a/repository/git.go
+++ b/repository/git.go
@@ -185,39 +185,6 @@ func createBranchWithAPI(ctx context.Context, opts createBranchOptions) error {
 	return nil
 }
 
-type resetBranchOptions struct {
-	GitHubOpts GitHubOptions
-	Repository Repository
-	BranchName string
-	CommitSHA  string
-}
-
-func resetBranchWithAPI(ctx context.Context, opts resetBranchOptions) error {
-	client, _, err := githubClient(ctx, opts.GitHubOpts)
-	if err != nil {
-		return fmt.Errorf("failed to create github client: %w", err)
-	}
-
-	branchRef := fmt.Sprintf("refs/heads/%s", opts.BranchName)
-
-	_, _, err = client.Git.UpdateRef(
-		ctx,
-		opts.Repository.Owner,
-		opts.Repository.Name,
-		&github.Reference{
-			Ref: &branchRef,
-			Object: &github.GitObject{
-				SHA: &opts.CommitSHA,
-			},
-		},
-		true,
-	)
-	if err != nil {
-		return fmt.Errorf("failed to update branch ref: %w", err)
-	}
-	return nil
-}
-
 type switchBranchOptions struct {
 	Repository   Repository
 	BranchName   string
@@ -386,8 +353,8 @@ func buildDiffTreeEntries(ctx context.Context, base, head *object.Commit) ([]*gi
 
 	for _, c := range treeDiff {
 		var path, mode, treeType, sha, content *string
-
 		var entry object.TreeEntry
+
 		switch c.To.TreeEntry.Mode {
 		case filemode.Empty:
 			entry = c.From.TreeEntry

--- a/repository/pull_request.go
+++ b/repository/pull_request.go
@@ -965,7 +965,7 @@ func isCheckConclusionPassing(c *githubv4.CheckConclusionState) bool {
 	if c == nil {
 		return false
 	}
-	switch *c { //nolint: exhaustive // default should catch the rest
+	switch *c {
 	case githubv4.CheckConclusionStateSuccess, githubv4.CheckConclusionStateNeutral, githubv4.CheckConclusionStateSkipped:
 		return true
 	default:

--- a/repository/utils.go
+++ b/repository/utils.go
@@ -2,9 +2,7 @@ package repository
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
-	"os"
 	"slices"
 
 	"github.com/google/go-github/v57/github"

--- a/repository/utils.go
+++ b/repository/utils.go
@@ -79,12 +79,3 @@ func searchRepositories(ctx context.Context, ghClient *github.Client, query stri
 
 	return repos, resp, nil
 }
-
-// base64EncodeFile returns the contents of a file in base64
-func base64EncodeFile(path string) (string, error) {
-	fileContent, err := os.ReadFile(path)
-	if err != nil {
-		return "", fmt.Errorf("unable to read file: %w", err)
-	}
-	return base64.StdEncoding.EncodeToString(fileContent), nil
-}


### PR DESCRIPTION
Fixing a few things:

- Use Github REST API to create Git trees & commits. This let's us update submodules commits too. It will still lead to a "verified" commit. For example, to update a submodule, run:
  ```
  octopilot ... --git-recurse-submodules --update 'exec(cmd=git,args=checkout xxxxxx,path=/submodule-path)'
  ```

- Reset strategy did not actually work. It would just close the PR after the force-push.

- Also the recurse submodule init hack was not substituting the URL correctly

#348