### PR TITLE
fix: use more generic logic to normalise repository URL

### DIFF
--- a/internal/git/config.go
+++ b/internal/git/config.go
@@ -65,12 +65,16 @@ func CurrentRepositoryURL() string {
 		return ""
 	}
 	repoURL := getConfigValue(filepath.Join(gitDir, "config"), "remote.origin.url")
-	repoURL = strings.TrimSuffix(repoURL, ".git")
-	repoURL = strings.TrimPrefix(repoURL, "git@github.com:")
-	if len(repoURL) > 0 && !strings.HasPrefix(repoURL, "http") {
-		repoURL = "https://github.com/" + repoURL
+	return normaliseRepositeURL(repoURL)
+}
+
+func normaliseRepositeURL(url string) string {
+	if strings.HasPrefix(url, "git@") {
+		url = strings.Replace(url, ":", "/", 1)
+		url = strings.Replace(url, "git@", "https://", 1)
 	}
-	return repoURL
+	url = strings.TrimSuffix(url, ".git")
+	return url
 }
 
 // getConfigValue returns the value associated with the given key in the given git config file path.

--- a/internal/git/config_test.go
+++ b/internal/git/config_test.go
@@ -57,6 +57,44 @@ func TestFindGitDirectory(t *testing.T) {
 	}
 }
 
+func TestNormaliseRepositeURL(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "ssh url",
+			input:    "git@github.com:dailymotion-oss/octopilot.git",
+			expected: "https://github.com/dailymotion-oss/octopilot",
+		},
+		{
+			name:     "https url",
+			input:    "https://github.com/dailymotion-oss/octopilot",
+			expected: "https://github.com/dailymotion-oss/octopilot",
+		},
+		{
+			name:     "ghe ssh url",
+			input:    "git@github.example.com:dailymotion-oss/octopilot.git",
+			expected: "https://github.example.com/dailymotion-oss/octopilot",
+		},
+		{
+			name:     "ghe https url",
+			input:    "https://github.example.com/dailymotion-oss/octopilot",
+			expected: "https://github.example.com/dailymotion-oss/octopilot",
+		},
+	}
+
+	for i := range tests {
+		test := tests[i]
+		t.Run(test.name, func(t *testing.T) {
+			actual := normaliseRepositeURL(test.input)
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}
+
 // note that this test can't be run in parallel, because it needs to change the working directory
 func TestCurrentRepositoryURL(t *testing.T) {
 	baseDir, err := os.Getwd()


### PR DESCRIPTION
The eariler approach assumed the domain would be `github.com` and hence did not work for SSH URLs of GitHub Enterprise Servers.

re #164 