### PR TITLE
ci: add multi-arch docker builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,12 +19,17 @@ jobs:
       - id: tag
         run: echo ::set-output name=TAG::${GITHUB_REF##*/}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker-container
+
       - name: Login to GitHub Packages Docker Registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.DM_BOT_TOKEN }}
+          password: ${{ secrets.DM_BOT_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Generate Changelog
         uses: docker://quay.io/git-chglog/git-chglog:0.14.2

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,23 +16,29 @@ builds:
       - CGO_ENABLED=0
 
 archives:
-  - format: binary
+  - formats: [binary]
 
-dockers:
+dockers_v2:
   - dockerfile: Dockerfile.goreleaser
-    image_templates:
-      - "ghcr.io/dailymotion-oss/{{.ProjectName}}:{{ .Version }}"
-      - "ghcr.io/dailymotion-oss/{{.ProjectName}}:{{ .Tag }}"
-      - "ghcr.io/dailymotion-oss/{{.ProjectName}}:v{{ .Major }}"
-      - "ghcr.io/dailymotion-oss/{{.ProjectName}}:v{{ .Major }}.{{ .Minor }}"
-      - "ghcr.io/dailymotion-oss/{{.ProjectName}}:latest"
-    build_flag_templates:
+    images:
+      - 'ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY_OWNER" "dailymotion-oss" }}/{{.ProjectName}}'
+    tags:
+      - "{{ .Version }}"
+      - "{{ .Tag }}"
+      - "v{{ .Major }}"
+      - "v{{ .Major }}.{{ .Minor }}"
+      - "latest"
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    flags:
       - "--pull"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.name={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--label=org.opencontainers.image.source={{.GitURL}}"
+    labels:
+      org.opencontainers.image.created: "{{.Date}}"
+      org.opencontainers.image.name: "{{.ProjectName}}"
+      org.opencontainers.image.revision: "{{.FullCommit}}"
+      org.opencontainers.image.version: "{{.Version}}"
+      org.opencontainers.image.source: "{{.GitURL}}"
 
 changelog:
   sort: asc

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,4 +1,4 @@
-FROM scratch
+FROM cgr.dev/chainguard/static:latest
 ARG TARGETPLATFORM
-ENTRYPOINT ["/octopilot"]
-COPY $TARGETPLATFORM/octopilot /
+COPY $TARGETPLATFORM/octopilot /usr/local/bin/octopilot
+ENTRYPOINT ["/usr/local/bin/octopilot"]

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,10 +1,4 @@
-# Dockerfile used by GoReleaser
-# Requires the binary to be pre-built
-
-FROM alpine:3.15
-
-RUN apk add --no-cache ca-certificates
-
-COPY octopilot /usr/local/bin/octopilot
-
-ENTRYPOINT ["octopilot"]
+FROM scratch
+ARG TARGETPLATFORM
+ENTRYPOINT ["/octopilot"]
+COPY $TARGETPLATFORM/octopilot /


### PR DESCRIPTION
This sets up GoReleaser and CI to build multi-arch Docker images for AMD64 and ARM64.

Tested to some degree on my fork, although later steps related to Hugo fail and fixing that is outside of my concern.